### PR TITLE
Update README to include dynamic keys function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 
 node_js:
   - 0.10
-
+  - 0.12
+  - iojs

--- a/README.md
+++ b/README.md
@@ -6,15 +6,19 @@
 
 JSON Web Token authentication requires verifying a signed token. The `'jwt'` scheme takes the following options:
 
-- `key` - (required) The private key the token was signed with.
-- `validateFunc` - (optional) validation and user lookup function with the signature `function(token, callback)` where:
+- `key` - (required) Either the private key the token was signed with or a key lookup function with signature `function(token, callback)` where:
+    - `token` - the *unverified* encoded jwt token
+    - `callback` - a callback function with the signature `function(err, key, extraInfo)` where:
+        - `err` - an internal error
+        - `key` - the private key that will be used to verify the token
+        - `extraInfo` - data that will be passed to `validateFunc` (e.g. credentials)
+- `validateFunc` - (optional) validation and user lookup function with the signature `function(token, extraInfo, callback)` where:
     - `token` - the verified and decoded jwt token
+    - `extraInfo` - data that was passed from the key lookup function (e.g. credentials)
     - `callback` - a callback function with the signature `function(err, isValid, credentials)` where:
         - `err` - an internal error.
         - `isValid` - `true` if the token was valid otherwise `false`.
-        - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
-          included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
-          (e.g. with authentication mode `'try'`).
+        - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails (e.g. with authentication mode `'try'`).
 
 See the example folder for an executable example.
 
@@ -26,7 +30,6 @@ var Hapi = require('hapi'),
 
 server.connection({ port: 8080 });
 
-
 var accounts = {
     123: {
         id: 123,
@@ -36,7 +39,6 @@ var accounts = {
     }
 };
 
-
 var privateKey = 'BbZJjyoXAdr8BUZuiKKARWimKfrSmQ6fv8kZ7OFfc';
 
 // Use this token to build your request with the 'Authorization' header.  
@@ -44,8 +46,7 @@ var privateKey = 'BbZJjyoXAdr8BUZuiKKARWimKfrSmQ6fv8kZ7OFfc';
 //     Authorization: Bearer <token>
 var token = jwt.sign({ accountId: 123 }, privateKey);
 
-
-var validate = function (decodedToken, callback) {
+var validate = function (decodedToken, extraInfo, callback) {
 
     var error,
         credentials = accounts[decodedToken.accountId] || {};
@@ -56,7 +57,6 @@ var validate = function (decodedToken, callback) {
 
     return callback(error, true, credentials)
 };
-
 
 server.register(require('hapi-auth-jwt'), function (error) {
 
@@ -86,6 +86,89 @@ server.register(require('hapi-auth-jwt'), function (error) {
     });
 });
 
+server.start();
+
+```
+
+With a key lookup method:
+
+```javascript
+
+var Hapi = require('hapi'),
+    jwt = require('jsonwebtoken'),
+    server = new Hapi.Server();
+
+server.connection({ port: 8080 });
+
+var accounts = {
+    123: {
+        id: 123,
+        user: 'john',
+        fullName: 'John Doe',
+        privateKey: 'BbZJjyoXAdr8BUZuiKKARWimKfrSmQ6fv8kZ7OFfc'
+        scope: ['a', 'b']
+    }
+};
+
+var getKey = function(token, callback) {
+  var data = jwt.decode(token);
+  var account = accounts[data.id];
+  var key = account.privateKey;
+
+  var credentials = {
+    id: account.id,
+    user: account.user
+    fullName: account.fullName,
+    scope: account.scope
+  }
+
+  callback(null, key, credentials);
+}
+
+// Use this token to build your request with the 'Authorization' header.  
+// Ex:
+//     Authorization: Bearer <token>
+var token = jwt.sign({ accountId: 123 }, privateKey);
+
+var validate = function (decodedToken, extraInfo, callback) {
+
+    var error,
+        credentials = extraInfo || {};
+
+    if (!credentials) {
+        return callback(error, false, credentials);
+    }
+
+    return callback(error, true, credentials)
+};
+
+server.register(require('hapi-auth-jwt'), function (error) {
+
+    server.auth.strategy('token', 'jwt', {
+        key: getKey,
+        validateFunc: validate
+    });
+
+    server.route({
+        method: 'GET',
+        path: '/',
+        config: {
+            auth: 'token'
+        }
+    });
+
+    // With scope requirements
+    server.route({
+        method: 'GET',
+        path: '/withScope',
+        config: {
+            auth: {
+                strategy: 'token',
+                scope: ['a']
+            }
+        }
+    });
+});
 
 server.start();
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ var validate = function (decodedToken, callback) {
 };
 
 
-server.register(require('../index'), function (error) {
+server.register(require('hapi-auth-jwt'), function (error) {
 
     server.auth.strategy('token', 'jwt', {
         key: privateKey,

--- a/example/index.js
+++ b/example/index.js
@@ -1,4 +1,5 @@
 var Hapi = require('hapi'),
+    hapiAuthJwt = require('../index'),
     jwt = require('jsonwebtoken'),
     server = new Hapi.Server();
 
@@ -33,11 +34,10 @@ var validate = function (decodedToken, callback) {
       return callback(null, false);
     }
 
-    return callback(null, true, account)
+    return callback(null, true, account);
 };
 
-
-server.register(require('../index'), function (err) {
+server.register(hapiAuthJwt, function () {
 
     server.auth.strategy('token', 'jwt', { key: privateKey,  validateFunc: validate });
 

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "hapi": "8.x.x",
-    "hapi-auth-jwt": "0.2.x",
+    "hapi-auth-jwt": "2.x.x",
     "jsonwebtoken": "1.3.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "boom": "2.x.x",
     "hoek": "2.x.x",
-    "jsonwebtoken": "1.3.x"
+    "jsonwebtoken": "3.2.x"
   },
   "peerDependencies": {
     "hapi": ">=8.x.x"
@@ -28,9 +28,9 @@
     "hapi": "8.x.x",
     "lab": "5.x.x",
     "grunt": "0.4.x",
-    "grunt-contrib-jshint": "0.10.x",
+    "grunt-contrib-jshint": "0.11.x",
     "grunt-contrib-watch": "0.6.x",
-    "grunt-bump": "0.0.16"
+    "grunt-bump": "0.1.x"
   },
   "scripts": {
     "test": "make test-cov"

--- a/test/dynamicKeys.tests.js
+++ b/test/dynamicKeys.tests.js
@@ -3,7 +3,7 @@
 var Lab  = require('lab');
 var Hapi = require('hapi');
 var Code = require('code');
-var Hoek = require('hoek')
+var Hoek = require('hoek');
 var Boom = require('boom');
 var jwt  = require('jsonwebtoken');
 
@@ -25,7 +25,7 @@ describe('Dynamic Secret', function () {
   var info = {
     'john': 'johninfo',
     'jane': 'janeinfo',
-  }
+  };
 
   var tokenHeader = function (username, options) {
     if (!keys[username]){
@@ -47,20 +47,20 @@ describe('Dynamic Secret', function () {
     Hoek.nextTick(function(){
       callback(null, keys[data.username], info[data.username]);
     })();
-  }
+  };
 
   var validateFunc = function(decoded, extraInfo, callback){
     validateFunc.lastExtraInfo = extraInfo;
     callback(null, true, decoded);
-  }
+  };
 
   var errorGetKey = function(token, callback){
     callback(new Error('Failed'));
-  }
+  };
 
   var boomErrorGetKey = function(token, callback){
     callback(Boom.forbidden('forbidden'));
-  }
+  };
 
   var server = new Hapi.Server({ debug: false });
   server.connection();


### PR DESCRIPTION
I've pulled the latest from ryanfitz/hapi-auth-jwt and updated the README with more instructions to describe how to use the dynamic keys function.