### PR TITLE
SEC: add semgrep integration

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,13 @@
+name: Semgrep
+on:
+  pull_request: {}
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
+    steps:
+      - uses: actions/checkout@v2
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,13 +1,19 @@
 name: Semgrep
 on:
   pull_request: {}
+  push:
+    branches: ["master", "main"]
+permissions:
+  contents: read
 jobs:
   semgrep:
     name: Scan
     runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]' && github.actor != 'snyk-bot')
     steps:
-      - uses: actions/checkout@v2
-      - uses: returntocorp/semgrep-action@v1
-        with:
-          publishToken: ${{ secrets.SEMGREP_APP_TOKEN }}
+      - uses: actions/checkout@v3
+      - run: semgrep ci
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
### Description

This PR introduces the semgrep integration. It resolves the below [Security Compass issue for this repo](https://security-compass.auth0.net/overview/14966): 
<img width="603" alt="Screenshot 2023-08-23 at 5 43 49 PM" src="https://github.com/auth0/hapi-auth-jwt/assets/34141289/1979a562-52bb-4b2e-865e-9693ae43c63a">

As you can see in the [Semgrep integration guidelines](https://oktawiki.atlassian.net/wiki/spaces/PSA/pages/2545714523/Semgrep+Integration+Procedure#Test-Semgrep-into-your-repositories-locally), we need to merge the integration PR to trigger the first scan:
![Screenshot 2023-08-24 at 11 29 55 AM](https://github.com/auth0/hapi-auth-jwt/assets/34141289/09e270be-99cf-404e-acdb-b70012f3bf33)

### References

https://security-compass.auth0.net/overview/14966/Semgrep

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
